### PR TITLE
Add Dockerfiles for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ backend/    # Medusa.js API
 database/   # SQL схемы и данные
 ```
 
+## Docker
+В каталогах `backend` и `frontend` добавлены собственные `Dockerfile` на основе Node 20. 
+Они копируют код, устанавливают зависимости и запускают:
+- `backend` – `medusa develop` (порт 9000)
+- `frontend` – `next start` (порт 3000)
+
+Сборка и запуск всех сервисов выполняется командой:
+```bash
+docker-compose up --build
+```
+
 ## Быстрый старт
 1. Скопируйте `.env.example` в `.env` и установите переменные.
 2. Запустите локально:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 9000
+CMD ["medusa", "develop"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,9 @@ services:
     ports:
       - '6379:6379'
   backend:
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
     command: npm run develop
     volumes:
       - ./backend:/app
@@ -30,7 +32,9 @@ services:
       - db
       - redis
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
     command: npm run dev
     volumes:
       - ./frontend:/app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["next", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile under `backend/` that runs `medusa develop`
- add Dockerfile under `frontend/` that runs `next start`
- update compose file to reference these Dockerfiles
- document the Dockerfiles and build command in README

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_684135e37fdc832e96423976e482201d